### PR TITLE
Improve CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,19 +42,19 @@ When asked for the commit message for the merge, please reference the issues tha
 When the changes have been merged into the oldest applicable branch, the changes should be merged in a cascading fashion to all the newer branches. With the current branches, it looks like this:
 
 ```
-git checkout 2.2.1834
+git checkout 2.2.1834 && git pull
 git merge 2.1.177
 git push
 
-git checkout 2.2.1.3234
+git checkout 2.2.1.3234 && git pull
 git merge 2.2.1834
 git push
 
-git checkout RC
+git checkout RC && git pull
 git merge 2.2.1.3234
 git push
 
-git checkout Develop
+git checkout Develop && git pull
 git merge RC
 git push
 ```


### PR DESCRIPTION
I'd like to propose a change to the contributing instructions:

add `git pull` after `checkout` to make sure that you have the current upstream state before doing the merge