### PR TITLE
Crazy idea

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -6,14 +6,24 @@ Use the navigation on the left to learn how to use Starcounter's interfaces for 
 
 Here's a recommended reading list for those that want to learn the most fundamental features of Starcounter:
 
-| Database  | View-Model | Development | Web  |
-|---|---|---|---|---|
-| [Database](database)  |  [Typed JSON](typed-json) | [Working in Visual Studio](working-with-starcounter/working-in-visual-studio)  | [Starcounter MVVM](web-apps/starcounter-mvvm)  |  
-|  [Creating Database Classes](database/creating-database-classes) | [JSON-by-example](typed-json/json-by-example)  |  [Administrator Web UI](working-with-starcounter/administrator-web-ui) |  [Client-Side Stack](web-apps/client-side-stack) |
-| [Data Manipulation](database/data-manipulation)  | [Code-Behind](typed-json/code-behind)  |  [Starting and Stopping Apps](working-with-starcounter/starting-and-stopping-apps) | [HTML Views](web-apps/html-views)  | 
-| [SQL](SQL)  |  [JSON Data Bindings](typed-json/json-data-bindings) |  [Mapping and Blending](mapping-and-blending) |  [Handling HTTP Requests](network/handling-http-requests) | 
-| [Transactions](transactions)  |   | | [Creating HTTP Responses](network/creating-http-responses)  |
-|  [Using Transactions](transactions/using-transactions) | 
 {% import "../macros.html" as macros %}
 
-{{ macros.tocGenerator(page.title, summary.parts[0].articles[3].articles) }}
+{% set featured_subpages = [
+    "guides/database/data-manipulation/README.md",
+    "guides/database/creating-database-classes/README.md",
+    "guides/transactions/using-transactions/README.md",
+    "guides/typed-json/json-by-example/README.md",
+    "guides/typed-json/code-behind/README.md",
+    "guides/typed-json/json-data-bindings/README.md",
+    "guides/working-with-starcounter/working-in-visual-studio/README.md",
+    "guides/working-with-starcounter/administrator-web-ui/README.md",
+    "guides/working-with-starcounter/starting-and-stopping-apps/README.md",
+    "guides/web-apps/starcounter-mvvm/README.md",
+    "guides/web-apps/client-side-stack/README.md",
+    "guides/web-apps/html-views/README.md",
+    "guides/network/handling-http-requests/README.md",
+    "guides/network/creating-http-responses/README.md"
+  ]
+%}
+
+{{ macros.tocGenerator(page.title, summary.parts[0].articles[3].articles, featured_subpages) }}

--- a/macros.html
+++ b/macros.html
@@ -1,4 +1,4 @@
-{% macro tocGenerator(pageTitle, articles) %}
+{% macro tocGenerator(pageTitle, articles, featured_subpages) %}
   <div class="part-box">
     <h2 class="toc-headline">Articles in the {{ pageTitle }} section</h2>
     {% for article in articles %}
@@ -6,6 +6,28 @@
         <a href="../../{{ article.path }}"><p class="toc-text">{{ article.title }}</p></a>
       {% elif article.depth == 2 %}
         <a href="../{{ article.path }}"><p class="toc-text">{{ article.title }}</p></a>
+      {% endif %}
+
+      {% set has_subpages = false %}
+      {% for subpage in article.articles %}
+        {% if featured_subpages.indexOf(subpage.path) != -1 %}
+          {% if has_subpages == false %}
+            {% set has_subpages = true %}
+            <p class="toc-text toc-subpage toc-subpage--first">(</p>
+          {% else %}
+            <p class="toc-text toc-subpage">•</p>
+          {% endif %}
+
+          {% if subpage.depth == 3 %}
+            <a href="../../{{ subpage.path }}"><p class="toc-text toc-subpage">{{ subpage.title }}</p></a>
+          {% elif subpage.depth == 2 %}
+            <a href="../{{ subpage.path }}"><p class="toc-text toc-subpage">{{ subpage.title }}</p></a>
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+      {% if has_subpages == true %}
+        {% set has_subpages = false %}
+        <p class="toc-text toc-subpage toc-subpage--last">)</p>
       {% endif %}
     {% endfor %}
   </div>

--- a/styles/website.css
+++ b/styles/website.css
@@ -75,6 +75,20 @@ pre::after {
   width: 100%;
 }
 
+.toc-text.toc-subpage {
+  font-size: 90%;
+  margin-top: 0.4em;
+  margin-left: 4px;
+}
+
+.toc-text.toc-subpage--first {
+  margin-right: -4px;
+}
+
+.toc-text.toc-subpage--last {
+  margin-right: 1px;
+}
+
 .code-name + pre code {
     border-radius: 0 3px 3px 3px;
 }
@@ -456,8 +470,8 @@ a .js-toolbar-action {
 }
 
 .report-errors-link {
-  position: fixed; 
-  bottom: 20px; 
+  position: fixed;
+  bottom: 20px;
   right: 20px;
   padding: 2px;
   color: black;


### PR DESCRIPTION
I just had this crazy idea, that there might be a different way to do the essential reading list in https://docs.starcounter.io/guides/. 

What I mean is that instead of this:

<img width="1210" alt="screen shot 2017-04-21 at 22 20 46" src="https://cloud.githubusercontent.com/assets/566463/25294782/1e8d7926-26e1-11e7-8048-d5f15d8c3b3e.png">

We could have this:

<img width="1210" alt="screen shot 2017-04-21 at 22 20 50" src="https://cloud.githubusercontent.com/assets/566463/25294776/18a08bb6-26e1-11e7-88ef-a7e0a7136bab.png">

I have implemented it by adding another parameter to the macro. The paramter is an array of the featured subpage URIs.

It also has drawbacks (sometimes there are loose "(" at the end of a line, depending on the window size). Maybe if you like it, you could improve the styles.

@Mackiovello WDYT?