### PR TITLE
Simplify toc

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -6,32 +6,6 @@ Use the navigation on the left to learn how to use Starcounter's interfaces for 
 
 To learn the fundamentals of Starcounter, read the articles listed below with a <i>&#9733;</i> next to it.
 
-<style>
-    .guide-articles {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-    }
-
-    .guide-articles section {
-        display: flex;
-        flex-direction: column;
-        width: 100%;
-    }
-
-    @media screen and (min-width: 768px) {
-        .guide-articles section {
-            width: 50%;
-        }
-    }
-
-    @media screen and (min-width: 1024px) {
-        .guide-articles section {
-            width: 33.333%;
-        }
-    }
-</style>
-
 {% set recommended_reading = [
         "database",
         "typed json",

--- a/guides/README.md
+++ b/guides/README.md
@@ -2,6 +2,76 @@
 
 Use the navigation on the left to learn how to use Starcounter's interfaces for databases, view-models and networking in your apps. We have made sure that you will feel at home by using APIs that are similar to those you already know.
 
-{% import "../macros.html" as macros %}
+## Essential reading
 
-{{ macros.tocGenerator(page.title, summary.parts[0].articles[3].articles) }}
+To learn the fundamentals of Starcounter, read the articles listed below with a <i>&#9733;</i> next to it.
+
+<style>
+    .guide-articles {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .guide-articles section {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+    }
+
+    @media screen and (min-width: 768px) {
+        .guide-articles section {
+            width: 50%;
+        }
+    }
+
+    @media screen and (min-width: 1024px) {
+        .guide-articles section {
+            width: 33.333%;
+        }
+    }
+</style>
+
+{% set recommended_reading = [
+        "database",
+        "typed json",
+        "working in visual studio",
+        "starcounter mvvm",
+        "creating database classes",
+        "json-by-example",
+        "administrator web ui",
+        "client-side stack",
+        "data manipulation",
+        "code-behind",
+        "starting and stopping apps",
+        "html views",
+        "sql",
+        "json data bindings",
+        "mapping and blending",
+        "handling http requests",
+        "transactions",
+        "creating http responses",
+        "using transactions"
+    ]
+%}
+
+<h2>Articles in the guides:</h2>
+
+<div class="guide-articles">
+    {% for section in summary.parts[0].articles[3].articles %}
+        <section>
+        {% if recommended_reading.indexOf(section.title.toLowerCase()) != -1 %}
+            <h3><a href="../{{ section.path }}">{{ section.title }}&#9733;</a></h3>
+        {% else %}
+            <h3><a href="../{{ section.path }}">{{ section.title }}</a></h3>
+        {% endif %}
+            {% for article in section.articles %}
+                {% if recommended_reading.indexOf(article.title.toLowerCase()) != -1 %}
+                    <a href="../../{{ article.path }}">{{ article.title }}&#9733;</a>
+                {% else %}
+                    <a href="../../{{ article.path }}">{{ article.title }}</a>
+                {% endif %}
+            {% endfor %}
+        </section>
+    {% endfor %}
+</div>

--- a/macros.html
+++ b/macros.html
@@ -1,12 +1,14 @@
 {% macro tocGenerator(pageTitle, articles) %}
   <div class="toc">
-    <h2 class="toc__headline">Articles in the {{ pageTitle }} section</h2>
+    <h2>Articles in the {{ pageTitle }} section:</h2>
+    <ul>
     {% for article in articles %}
       {% if article.depth == 3 %}
-        <a href="../../{{ article.path }}"><p class="toc__text">{{ article.title }}</p></a>
+        <li><a href="../../{{ article.path }}">{{ article.title }}</a></li>
       {% elif article.depth == 2 %}
-        <a href="../{{ article.path }}"><p class="toc__text">{{ article.title }}</p></a>
+        <li><a href="../{{ article.path }}">{{ article.title }}</a></li>
       {% endif %}
     {% endfor %}
+    </ul>
   </div>
 {% endmacro %}

--- a/macros.html
+++ b/macros.html
@@ -1,11 +1,11 @@
 {% macro tocGenerator(pageTitle, articles) %}
-  <div class="part-box">
-    <h2 class="toc-headline">Articles in the {{ pageTitle }} section</h2>
+  <div class="toc">
+    <h2 class="toc__headline">Articles in the {{ pageTitle }} section</h2>
     {% for article in articles %}
       {% if article.depth == 3 %}
-        <a href="../../{{ article.path }}"><p class="toc-text">{{ article.title }}</p></a>
+        <a href="../../{{ article.path }}"><p class="toc__text">{{ article.title }}</p></a>
       {% elif article.depth == 2 %}
-        <a href="../{{ article.path }}"><p class="toc-text">{{ article.title }}</p></a>
+        <a href="../{{ article.path }}"><p class="toc__text">{{ article.title }}</p></a>
       {% endif %}
     {% endfor %}
   </div>

--- a/macros.html
+++ b/macros.html
@@ -3,11 +3,7 @@
     <h2>Articles in the {{ pageTitle }} section:</h2>
     <ul>
     {% for article in articles %}
-      {% if article.depth == 3 %}
-        <li><a href="../../{{ article.path }}">{{ article.title }}</a></li>
-      {% elif article.depth == 2 %}
-        <li><a href="../{{ article.path }}">{{ article.title }}</a></li>
-      {% endif %}
+      <li><a href="../../{{ article.path }}">{{ article.title }}</a></li>
     {% endfor %}
     </ul>
   </div>

--- a/styles/website.css
+++ b/styles/website.css
@@ -47,28 +47,24 @@ pre::after {
 }
 
 /* styling for article ToC on the bottom of each section page */
-.part-box {
+.markdown-section .toc {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
   align-content: space-around;
-  border-color: #f47e0c;
-  border-style: dotted;
-  border-width: 8px;
-  border-radius: 30px;
   font-family: 'Montserrat', Arial, Helvetica, sans-serif;
   margin-top: 20px;
 }
 
-.toc-text {
+.markdown-section .toc__text {
   color: black;
   margin-left: 15px;
   font-size: 20px;
   text-align: center;
 }
 
-.toc-headline {
+.markdown-section .toc__headline {
   margin-top: 0.5em !important;
   color: #f47e0c;
   text-align: center;
@@ -267,7 +263,7 @@ kbd {
 }
 
 @media (max-width: 700px) {
-  .toc-text {
+  .toc__text {
     font-size: larger !important;
     line-height: normal !important;
     margin-left: 1em !important;

--- a/styles/website.css
+++ b/styles/website.css
@@ -443,3 +443,27 @@ a .js-toolbar-action {
   color: black;
   border-bottom: 3px solid #f47e0c
 }
+
+.guide-articles {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
+
+.guide-articles section {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+@media screen and (min-width: 768px) {
+    .guide-articles section {
+        width: 50%;
+    }
+}
+
+@media screen and (min-width: 1024px) {
+    .guide-articles section {
+        width: 33.333%;
+    }
+}

--- a/styles/website.css
+++ b/styles/website.css
@@ -46,29 +46,8 @@ pre::after {
     display: none;
 }
 
-/* styling for article ToC on the bottom of each section page */
-.markdown-section .toc {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-content: space-around;
-  font-family: 'Montserrat', Arial, Helvetica, sans-serif;
-  margin-top: 20px;
-}
-
-.markdown-section .toc__text {
+.page-inner .markdown-section .toc a {
   color: black;
-  margin-left: 15px;
-  font-size: 20px;
-  text-align: center;
-}
-
-.markdown-section .toc__headline {
-  margin-top: 0.5em !important;
-  color: #f47e0c;
-  text-align: center;
-  width: 100%;
 }
 
 .code-name + pre code {

--- a/styles/website.css
+++ b/styles/website.css
@@ -242,14 +242,6 @@ kbd {
   }
 }
 
-@media (max-width: 700px) {
-  .toc__text {
-    font-size: larger !important;
-    line-height: normal !important;
-    margin-left: 1em !important;
-  }
-}
-
 /* Hide large menu buttons and display the dropdown button with moderately small screens */
 
 @media (max-width: 1040px) {

--- a/styles/website.css
+++ b/styles/website.css
@@ -46,6 +46,7 @@ pre::after {
     display: none;
 }
 
+.page-inner .markdown-section .guide-articles a,
 .page-inner .markdown-section .toc a {
   color: black;
 }


### PR DESCRIPTION
Simplify TOC for #66


The guide page now has a TOC page with all the pages so that the reader can get an overview. Essential reading is marked with a star:

![newtocguide](https://cloud.githubusercontent.com/assets/19392292/25471175/26a9fc8a-2b26-11e7-80a2-342dc5f67050.PNG)

The other pages have a simple list with the content:

![newtoc](https://cloud.githubusercontent.com/assets/19392292/25471176/278342ce-2b26-11e7-816d-295e4c94697d.PNG)
