### PR TITLE
Clarify about multiple tokens in Blender.MapUri and Self.GET

### DIFF
--- a/guides/blending/blending/README.md
+++ b/guides/blending/blending/README.md
@@ -94,3 +94,5 @@ Blender.MapUri("/app4/{?}", token2);
 ```
 
 Here handler "/app1/{?}" participates in blending with `token1` and `token2` handlers.
+
+When an app requests `Self.GET("/app1/xyz")`, both handlers mapped to `token1` and `token2` will be triggered.


### PR DESCRIPTION
This should clarify the problem that was identified in https://github.com/StarcounterApps/Images/issues/102#issuecomment-311591354

@alemoi, @bouguila, @miyconst is the description that I added valid?

I future please always consider expanding the docs when some pitfalls are identified during app development.