### PR TITLE
Use fully qualified name of the class

### DIFF
--- a/docs/topic-guides/blendable-web-apps/app-shell.md
+++ b/docs/topic-guides/blendable-web-apps/app-shell.md
@@ -30,10 +30,10 @@ The default content of the app shell is tied to the StarcounterClientFiles versi
 The app shell is invoked automatically for any `Json` with a `Html` property that is returned from your app. The only provision is that your app needs to register the following middleware:
 
 ```csharp
-Starcounter.Application.Current.
-    Use(new HtmlFromJsonProvider());
-Starcounter.Application.Current.
-    Use(new PartialToStandaloneHtmlProvider());
+Starcounter.Application.Current
+    .Use(new HtmlFromJsonProvider());
+Starcounter.Application.Current
+    .Use(new PartialToStandaloneHtmlProvider());
 ```
 
 The [middleware](../network/middleware.md#middleware-classes) page explains the APIs presented above. In short, the `HtmlFromJsonProvider` middleware fetches the view associated with a view-model, and `PartialToStandaloneHtmlProvider` wraps the view in the app shell.

--- a/docs/topic-guides/blendable-web-apps/app-shell.md
+++ b/docs/topic-guides/blendable-web-apps/app-shell.md
@@ -30,8 +30,10 @@ The default content of the app shell is tied to the StarcounterClientFiles versi
 The app shell is invoked automatically for any `Json` with a `Html` property that is returned from your app. The only provision is that your app needs to register the following middleware:
 
 ```csharp
-Application.Current.Use(new HtmlFromJsonProvider());
-Application.Current.Use(new PartialToStandaloneHtmlProvider());
+Starcounter.Application.Current.
+    Use(new HtmlFromJsonProvider());
+Starcounter.Application.Current.
+    Use(new PartialToStandaloneHtmlProvider());
 ```
 
 The [middleware](../network/middleware.md#middleware-classes) page explains the APIs presented above. In short, the `HtmlFromJsonProvider` middleware fetches the view associated with a view-model, and `PartialToStandaloneHtmlProvider` wraps the view in the app shell.


### PR DESCRIPTION
use fully qualified name of the class, because otherwise there is a conflict when the app developer has a namespace called `Application` in his app.