### PR TITLE
Fix hardcoded links

### DIFF
--- a/docs/how-to-guides/how-to-create-single-page-apps.md
+++ b/docs/how-to-guides/how-to-create-single-page-apps.md
@@ -142,11 +142,11 @@ namespace MultiplePagesDemo
 {% endcode-tabs-item %}
 {% endcode-tabs %}
 
-The program defines two [`Handle.GET`](https://docs.starcounter.io/guides/network/handling-http-requests/) operations. One to retrieve the master, MailsPage, and the other to retrieve specific emails.
+The program defines two [`Handle.GET`](../topic-guides/network/http.md) operations. One to retrieve the master, MailsPage, and the other to retrieve specific emails.
 
 The first, `Handle.GET("/MultiplePagesDemo/mails"...`, returns the master json MailsPage. It checks if there is a current session and if so uses it instead of creating a new. It uses the first mail, if any, as the focused mail.
 
-The second, `Handle.GET("/multiplepagesdemo/mails/{?}"...`, returns a MailsPage as well. It does however specify which email should be focused. By relying on [`Self.GET`](https://docs.starcounter.io/guides/network/internal-self-calls/) we call the first handler which includes the functionality to check for exisiting sessions.
+The second, `Handle.GET("/multiplepagesdemo/mails/{?}"...`, returns a MailsPage as well. It does however specify which email should be focused. By relying on [`Self.GET`](../topic-guides/network/http.md#internal-calls) we call the first handler which includes the functionality to check for exisiting sessions.
 
 ### View
 

--- a/docs/topic-guides/blendable-web-apps/app-shell.md
+++ b/docs/topic-guides/blendable-web-apps/app-shell.md
@@ -19,7 +19,7 @@ The Starcounter app shell is a minimalist, configurable HTML document that impor
 * the `<starcounter-include>` custom element
 * Underwear.css, a CSS framework
 * a placeholder for the Web App Manifest \(`link rel="manifest"`\).
-* `starcounter.html` file that contains a script, which automatically adds the `aria-current-"page"` attribute to links which, for example, you can use to highlight the current link in the menu, like the [Uniform.css](https://docs.starcounter.io/v/2.4/topic-guides/blendable-web-apps/common-look-and-feel) `uni-layout-left-nav` class does.
+* `starcounter.html` file that contains a script, which automatically adds the `aria-current-"page"` attribute to links which, for example, you can use to highlight the current link in the menu, like the [Uniform.css](common-look-and-feel.md) `uni-layout-left-nav` class does.
 
 On page load, the app shell establishes the Palindrom session with the server, obtains the JSON view-model tree, inserts the root view using `<starcounter-include>` and connects the root view to the view-model.
 

--- a/docs/topic-guides/blendable-web-apps/html-views-composition-guidelines.md
+++ b/docs/topic-guides/blendable-web-apps/html-views-composition-guidelines.md
@@ -175,7 +175,7 @@ Here, the elements are distributed in the way that the view will look when no Co
 
 Regarding styling, there are few ways to make the application easier to visually integrate with other apps:
 
-1. Prefix all class names with the name of the app, as outlined in [Avoiding CSS Conflicts](https://docs.starcounter.io/guides/blending/avoiding-css-conflicts/).
+1. Prefix all class names with the name of the app, as outlined in [Avoiding CSS Conflicts](avoiding-css-conflicts.md).
 2. Keep styling that will affect the presentation inside the `declarative-shadow-dom`.
 3. To avoid writing the same Shadow DOM CSS on different pages, it can be imported with the CSS `import` rule. The syntax for this is `<style>@import url("/yourapp/css/style.css");</style>`. In the example above it would be done this way:
 

--- a/docs/topic-guides/working-with-starcounter/administrator-web-ui.md
+++ b/docs/topic-guides/working-with-starcounter/administrator-web-ui.md
@@ -56,9 +56,9 @@ Apps will start together with the database if "Auto-Start" is clicked. The padlo
 
 ### Execute SQL queries {#execute-sql-queries}
 
-The data of a database can be queried in the SQL browser. See [SQL reference](https://docs.starcounter.io/guides/sql) for details on the syntax.
+The data of a database can be queried in the SQL browser. See [SQL reference](../sql) for details on the syntax.
 
-The queries that are supported by the method `Db.SQL` are also supported except that [literals](https://docs.starcounter.io/guides/sql/literals) are used in the SQL browser instead of [variables](https://docs.starcounter.io/guides/database/variables).
+The queries that are supported by the method `Db.SQL` are also supported except that [literals](../sql/literals.md) are used in the SQL browser instead of [variables](../database/querying-with-sql.md#using-variables).
 
 The app that defines that table needs to run in order to query it.
 


### PR DESCRIPTION
they should point to the current version of the docs
right now, they point to the old version and/or 404 pages