### PR TITLE
Extensibility sources, samples and documentation

### DIFF
--- a/extensibility/OnDelete/IDeleteAware.cs
+++ b/extensibility/OnDelete/IDeleteAware.cs
@@ -1,0 +1,6 @@
+using Starcounter.Database;
+
+public interface IDeleteAware
+{
+    void OnDelete(IDatabaseContext db);
+}

--- a/extensibility/OnDelete/MyTransactor.cs
+++ b/extensibility/OnDelete/MyTransactor.cs
@@ -1,0 +1,24 @@
+using Starcounter.Database;
+using Starcounter.Database.Hosting.Extensibility;
+
+class MyTransactor : TransactorBase
+{
+    class MyContext : ContextBase
+    {
+        public MyContext(IDatabaseContext context) : base(context) { }
+
+        public override void Delete(object obj)
+        {
+            if (obj is IDeleteAware d)
+            {
+                d.OnDelete(this);
+            }
+
+            base.Delete(obj);
+        }
+    }
+
+    public MyTransactor(ITransactor transactor) : base(transactor) {}
+
+    protected override IDatabaseContext EnterContext(IDatabaseContext db) => new MyContext(db);
+}

--- a/extensibility/OnDelete/Program.cs
+++ b/extensibility/OnDelete/Program.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Starcounter.Database;
+
+namespace OnDeleteSample
+{
+    [Database]
+    public abstract class Person : IDeleteAware
+    {
+        public abstract string Name { get; set; }
+
+        public void OnDelete(IDatabaseContext db)
+        {
+            Console.WriteLine($"{Name} is about to be deleted.");
+        }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            using var services = new ServiceCollection()
+                .AddStarcounter($"Database=./.database/OnDeleteSample")
+                .AddSingleton<MyTransactor>()
+                .BuildServiceProvider();
+
+            ITransactor transactor = services.GetRequiredService<MyTransactor>();
+
+            transactor.Transact(db =>
+            {
+                var per = db.Insert<Person>();
+                per.Name = "Per";
+
+                db.Delete(per);
+            });
+
+            // Output:
+            // Per is about to be deleted.
+        }
+    }
+}

--- a/extensibility/OnDelete/README.md
+++ b/extensibility/OnDelete/README.md
@@ -9,4 +9,4 @@ Then copy `MyTransactor.cs` and `IDeleteAware.cs` to your application.
 Now you can implement `IDeleteAware.OnDelete` on your database types that need to take action when an instance of the type is deleted.
 
 ## Sample application
-Look at [`Program.cs`](./Program.cs) to see how its used.
+Look at [`Program.cs`](./Program.cs) to see how it is used.

--- a/extensibility/OnDelete/README.md
+++ b/extensibility/OnDelete/README.md
@@ -1,0 +1,12 @@
+# Overview
+Illustrates a way to support an `IDeleteAware` interface to be implemented by database classes, to recieve notifications when instances of the type is deleted.
+
+## Usage
+First copy sources from `..\Starcounter.Database.Hosting.Extensibility` to your application. We suggest you put them in a folder with the same name.
+
+Then copy `MyTransactor.cs` and `IDeleteAware.cs` to your application.
+
+Now you can implement `IDeleteAware.OnDelete` on your database types that need to take action when an instance of the type is deleted.
+
+## Sample application
+Look at `Program.cs` to see how its used.

--- a/extensibility/OnDelete/README.md
+++ b/extensibility/OnDelete/README.md
@@ -9,4 +9,4 @@ Then copy `MyTransactor.cs` and `IDeleteAware.cs` to your application.
 Now you can implement `IDeleteAware.OnDelete` on your database types that need to take action when an instance of the type is deleted.
 
 ## Sample application
-Look at `Program.cs` to see how its used.
+Look at [`Program.cs`](./Program.cs) to see how its used.

--- a/extensibility/PreCommitHooks/MyTransactor.cs
+++ b/extensibility/PreCommitHooks/MyTransactor.cs
@@ -1,0 +1,39 @@
+using System;
+using Starcounter.Database;
+using Starcounter.Database.Hosting.Extensibility;
+using Starcounter.Database.ChangeTracking;
+using Microsoft.Extensions.Options;
+using System.Linq;
+
+class MyTransactor : TransactorBase
+{
+    class MyContext : ContextBase
+    {
+        public MyContext(IDatabaseContext context) : base(context) { }
+
+        public void ExecutePreCommitHooks(PreCommitHookOptions options)
+        {
+            foreach (var change in ChangeTracker.Changes.Where(c => c.ChangeType != ChangeType.Delete))
+            {
+                var proxy = Get<object>(change.Id);
+                var realType = proxy.GetType().BaseType;
+
+                if (options.Delegates.TryGetValue(realType, out Action<IDatabaseContext, Change> action))
+                {
+                    action(this, change);
+                }
+            }
+        }
+    }
+
+    readonly PreCommitHookOptions hookOptions;
+
+    public MyTransactor(ITransactor transactor, IOptions<PreCommitHookOptions> preCommitHookOptions)
+        : base(transactor)
+        => hookOptions = preCommitHookOptions.Value;
+
+    protected override IDatabaseContext EnterContext(IDatabaseContext db) => new MyContext(db);
+
+    protected override void LeaveContext(IDatabaseContext db)
+        => ((MyContext)db).ExecutePreCommitHooks(hookOptions);
+}

--- a/extensibility/PreCommitHooks/PreCommitHookOptions.cs
+++ b/extensibility/PreCommitHooks/PreCommitHookOptions.cs
@@ -1,0 +1,12 @@
+using System;
+using Starcounter.Database;
+using System.Collections.Generic;
+using Starcounter.Database.ChangeTracking;
+
+class PreCommitHookOptions
+{
+    internal IDictionary<Type, Action<IDatabaseContext, Change>> Delegates { get; } 
+        = new Dictionary<Type, Action<IDatabaseContext, Change>>();
+
+    public void Hook<T>(Action<IDatabaseContext, Change> action) => Delegates.Add(typeof(T), action);
+}

--- a/extensibility/PreCommitHooks/Program.cs
+++ b/extensibility/PreCommitHooks/Program.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Starcounter.Database;
+
+namespace PreCommitHooksSample
+{
+    [Database]
+    public abstract class Person
+    {
+        public abstract string Name { get; set; }
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            using var services = new ServiceCollection()
+                .AddStarcounter($"Database=./.database/PreCommitHooksSample")
+                .Configure<PreCommitHookOptions>(o => 
+                {
+                    // Here we register a delegate that will be called when an
+                    // object of type Person is either inserted or updated. The
+                    // delegate will execute as part of the same transaction that
+                    // executed the change.
+                    o.Hook<Person>((db, change) =>
+                    {
+                        Console.WriteLine($"{change.ChangeType} of person with id {change.Id}.");
+                    });
+                })
+                .AddSingleton<MyTransactor>()
+                .BuildServiceProvider();
+
+            ITransactor transactor = services.GetRequiredService<MyTransactor>();
+
+            // Execute 2 transactions. The first one inserts a person,
+            // and returns the unique identity of the person. The second
+            // one updates the person created in the first.
+
+            var id = transactor.Transact(db =>
+            {
+                var per = db.Insert<Person>();
+                per.Name = "Per";
+                return db.GetOid(per);
+            });
+
+            transactor.Transact(db =>
+            {
+                var per = db.Get<Person>(id);
+                per.Name = "Per Samuelsson";
+            });
+
+            // Output:
+            // Insert of person with id 1
+            // Update of person with id 1
+        }
+    }
+}

--- a/extensibility/PreCommitHooks/README.md
+++ b/extensibility/PreCommitHooks/README.md
@@ -1,0 +1,12 @@
+# Overview
+Illustrates a way to implement *pre-commit hooking* in an application using the Starcounter database.
+
+## Usage
+First copy sources from `..\Starcounter.Database.Hosting.Extensibility` to your application. We suggest you put them in a folder with the same name.
+
+Then copy `MyTransactor.cs` and `PreCommitHookOptions.cs` to your application.
+
+Now you can configure `PreCommitHookOptions` and register callbacks in your application, that will get invoked when objects of specified types is either inserted or updated.
+
+## Sample application
+Look at `Program.cs` to see how its used.

--- a/extensibility/PreCommitHooks/README.md
+++ b/extensibility/PreCommitHooks/README.md
@@ -9,4 +9,4 @@ Then copy `MyTransactor.cs` and `PreCommitHookOptions.cs` to your application.
 Now you can configure `PreCommitHookOptions` and register callbacks in your application, that will get invoked when objects of specified types is either inserted or updated.
 
 ## Sample application
-Look at `Program.cs` to see how its used.
+Look at [`Program.cs`](./Program.cs) to see how its used.

--- a/extensibility/README.md
+++ b/extensibility/README.md
@@ -1,0 +1,11 @@
+# Overview
+Extensibility is about extending core features of the Starcounter database, using some suggested approaches available here as source code.
+
+## Organisation
+The [Starcounter.Database.Hosting.Extensibility](./Starcounter.Database.Hosting.Extensibility) folder contains sources that forms the foundation for the more specific samples.
+
+### OnDelete
+* [OnDelete](./OnDelete/README.md) suggest a way for any application to support an interface that can be applied to any database class and act as a callback when instances of that class is deleted from the database.
+
+### Pre-commit hooks
+* [PreCommitHooks](./PreCommitHooks/README.md) describe an approach where applications can register callbacks to be invoked when instances of a specified database type is either inserted or updated, just before a transaction is committed. 

--- a/extensibility/README.md
+++ b/extensibility/README.md
@@ -5,7 +5,7 @@ Extensibility is about extending core features of the Starcounter database, usin
 The [Starcounter.Database.Hosting.Extensibility](./Starcounter.Database.Hosting.Extensibility) folder contains sources that forms the foundation for the more specific samples.
 
 ### OnDelete
-* [OnDelete](./OnDelete) suggest a way for any application to support an interface that can be applied to any database class and act as a callback when instances of that class is deleted from the database.
+* [OnDelete](./OnDelete) demonstrates a way for any application to support an interface that can be applied to any database class and act as a callback when instances of that class is being deleted from the database.
 
 ### Pre-commit hooks
 * [PreCommitHooks](./PreCommitHooks) describe an approach where applications can register callbacks to be invoked when instances of a specified database type is either inserted or updated, just before a transaction is committed. 

--- a/extensibility/README.md
+++ b/extensibility/README.md
@@ -5,7 +5,7 @@ Extensibility is about extending core features of the Starcounter database, usin
 The [Starcounter.Database.Hosting.Extensibility](./Starcounter.Database.Hosting.Extensibility) folder contains sources that forms the foundation for the more specific samples.
 
 ### OnDelete
-* [OnDelete](./OnDelete/README.md) suggest a way for any application to support an interface that can be applied to any database class and act as a callback when instances of that class is deleted from the database.
+* [OnDelete](./OnDelete) suggest a way for any application to support an interface that can be applied to any database class and act as a callback when instances of that class is deleted from the database.
 
 ### Pre-commit hooks
-* [PreCommitHooks](./PreCommitHooks/README.md) describe an approach where applications can register callbacks to be invoked when instances of a specified database type is either inserted or updated, just before a transaction is committed. 
+* [PreCommitHooks](./PreCommitHooks) describe an approach where applications can register callbacks to be invoked when instances of a specified database type is either inserted or updated, just before a transaction is committed. 

--- a/extensibility/Starcounter.Database.Hosting.Extensibility/ContextBase.cs
+++ b/extensibility/Starcounter.Database.Hosting.Extensibility/ContextBase.cs
@@ -1,0 +1,29 @@
+using System;
+using Starcounter.Database.ChangeTracking;
+
+namespace Starcounter.Database.Hosting.Extensibility
+{
+    public abstract class ContextBase : IDatabaseContext
+    {
+        readonly IDatabaseContext _inner;
+
+        protected IDatabaseContext InnerContext { get => _inner; }
+
+        protected ContextBase(IDatabaseContext innerContext) 
+            => _inner = innerContext ?? throw new ArgumentNullException(nameof(innerContext));
+
+        public virtual IChangeTracker ChangeTracker => _inner.ChangeTracker;
+
+        public virtual void Delete(object obj) => _inner.Delete(obj);
+
+        public virtual new bool Equals(object objA, object objB) => _inner.Equals(objA, objB);
+
+        public virtual T Get<T>(ulong oid) => _inner.Get<T>(oid);
+
+        public virtual ulong GetOid(object databaseObject) => _inner.GetOid(databaseObject);
+
+        public virtual T Insert<T>() where T : class => _inner.Insert<T>();
+
+        public virtual ISqlResult<T> Sql<T>(string query, params object[] values) => _inner.Sql<T>(query, values);
+    }
+}

--- a/extensibility/Starcounter.Database.Hosting.Extensibility/TransactorBase.cs
+++ b/extensibility/Starcounter.Database.Hosting.Extensibility/TransactorBase.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Starcounter.Database.Hosting.Extensibility
+{
+    public abstract class TransactorBase : ITransactor
+    {
+        readonly ITransactor _inner;
+
+        protected ITransactor InnerTransactor { get => _inner; }
+        
+        protected TransactorBase(ITransactor innerTransactor) 
+            => _inner = innerTransactor ?? throw new ArgumentNullException(nameof(innerTransactor));
+
+        public virtual void Transact(Action<IDatabaseContext> action, TransactOptions options = null) 
+            => _inner.Transact(db => ExecuteCallback(db, action), options);
+
+        public virtual T Transact<T>(Func<IDatabaseContext, T> function, TransactOptions options = null) 
+            => _inner.Transact(db => ExecuteCallback(db, function), options);
+
+        public virtual Task TransactAsync(Action<IDatabaseContext> action, TransactOptions options = null) 
+            => _inner.TransactAsync(db => ExecuteCallback(db, action), options);
+
+        public virtual Task TransactAsync(Func<IDatabaseContext, Task> function, TransactOptions options = null) 
+            => _inner.TransactAsync(db => ExecuteCallback(db, function), options);
+
+        public virtual Task<T> TransactAsync<T>(Func<IDatabaseContext, T> function, TransactOptions options = null) 
+            => _inner.TransactAsync(db => ExecuteCallback(db, function), options);
+
+        public virtual Task<T> TransactAsync<T>(Func<IDatabaseContext, Task<T>> function, TransactOptions options = null) 
+            => _inner.TransactAsync(db => ExecuteCallback(db, function), options);
+
+        public virtual bool TryTransact(Action<IDatabaseContext> action, TransactOptions options = null) 
+            => _inner.TryTransact(db => ExecuteCallback(db, action), options);
+
+        protected virtual void ExecuteCallback(IDatabaseContext db, Action<IDatabaseContext> action)
+        {
+            var context = EnterContext(db);
+            try 
+            {
+                action(context);
+            }
+            finally
+            {
+                LeaveContext(context);
+            }
+        }
+
+        protected virtual T ExecuteCallback<T>(IDatabaseContext db, Func<IDatabaseContext, T> function) 
+        {
+            var context = EnterContext(db);
+            try 
+            {
+                return function(context);
+            }
+            finally
+            {
+                LeaveContext(context);
+            }
+        }
+
+        protected virtual Task ExecuteCallback(IDatabaseContext db, Func<IDatabaseContext, Task> function)
+        {
+            var context = EnterContext(db);
+            try 
+            {
+                return function(context);
+            }
+            finally
+            {
+                LeaveContext(context);
+            }
+        }
+
+        protected virtual Task<T> ExecuteCallback<T>(IDatabaseContext db, Func<IDatabaseContext, Task<T>> function)
+        {
+            var context = EnterContext(db);
+            try 
+            {
+                return function(context);
+            }
+            finally
+            {
+                LeaveContext(context);
+            }
+        }
+
+        /// <summary>
+        /// Invoked when a transaction has been created and bound to the current thread,
+        /// in a task that execute with a kernel context. The user delegate have not been
+        /// invoked yet.  
+        /// </summary>
+        /// <param name="db">The default database context</param>
+        /// <returns>A database context that will be passed to the delegate.</returns>
+        protected virtual IDatabaseContext EnterContext(IDatabaseContext db) => db;
+
+        /// <summary>
+        /// Invoked right after the user delegate has been executed, but when we are still
+        /// within the scope of the transaction and the kernel context.
+        /// </summary>
+        /// <param name="db">The database context returned by EnterContext.</param>
+        protected virtual void LeaveContext(IDatabaseContext db) {}
+    }
+}


### PR DESCRIPTION
Continuation of what we worked on in https://github.com/Starcounter/Starcounter.Nova/issues/1046.

The idea is to have `/extensibility` as a root for samples and snippets suggesting how to extend Starcounter from within applications, starting with these first ones that suggest an approach for OnDelete and pre-commit hooks.